### PR TITLE
Enable php81 tests for 401_STABLE and master (4.2dev)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,20 +29,20 @@ jobs:
       matrix:
         include:
           # Highest php versions supported by each branch (with master always being tested twice).
-          # TODO: Enable when master (4.2dev) supports php81
-          #- php: 8.1
-          #  moodle-branch: master
-          #  database: pgsql
-          #  # The following line is only needed if you're going to run php8 jobs and your
-          #  # plugin needs xmlrpc services.
-          #  extensions: xmlrpc-beta
-          #- php: 8.1
-          #  moodle-branch: master
-          #  database: mariadb
-          #  # The following line is only needed if you're going to run php8 jobs and your
-          #  # plugin needs xmlrpc services.
-          #  extensions: xmlrpc-beta
-          - php: 8.0
+          - php: 8.1
+            moodle-branch: master
+            database: pgsql
+            # The following line is only needed if you're going to run php8 jobs and your
+            # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+          - php: 8.1
+            moodle-branch: master
+            database: mariadb
+            # The following line is only needed if you're going to run php8 jobs and your
+            # plugin needs xmlrpc services.
+            extensions: xmlrpc-beta
+
+          - php: 8.1
             moodle-branch: MOODLE_401_STABLE
             database: pgsql
             # The following line is only needed if you're going to run php8 jobs and your
@@ -62,6 +62,7 @@ jobs:
             # The following line is only needed if you're going to run php8 jobs and your
             # plugin needs xmlrpc services.
             extensions: xmlrpc-beta
+
           - php: 7.4
             moodle-branch: MOODLE_401_STABLE
             database: pgsql

--- a/lib.php
+++ b/lib.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+// phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.xmlrpc_decode_requestRemoved
+// phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.xmlrpc_encode_requestRemoved
+// phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.xmlrpc_is_faultRemoved
+
 /**
  * Moodle XML-RPC client
  *

--- a/locallib.php
+++ b/locallib.php
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+// phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.xmlrpc_decode_requestRemoved
+// phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.xmlrpc_encode_requestRemoved
+
 /**
  * XML-RPC web service implementation classes and methods.
  *
@@ -72,7 +75,12 @@ class webservice_xmlrpc_server extends webservice_base_server {
 
         // Decode the request to get the decoded parameters and the name of the method to be called.
         $decodedparams = xmlrpc_decode_request($rawpostdata, $methodname, 'UTF-8');
-        $methodinfo = external_api::external_function_info($methodname);
+        if (class_exists('\core_external\external_api')) {
+            $methodinfo = \core_external\external_api::external_function_info($methodname);
+        } else {
+            // TODO: Remove this branch condition once Moodle 4.1 is out of support.
+            $methodinfo = external_api::external_function_info($methodname);
+        }
         $methodparams = array_keys($methodinfo->parameters_desc->keys);
         $methodvariables = [];
 
@@ -104,7 +112,15 @@ class webservice_xmlrpc_server extends webservice_base_server {
     protected function prepare_response() {
         try {
             if (!empty($this->function->returns_desc)) {
-                $validatedvalues = external_api::clean_returnvalue($this->function->returns_desc, $this->returns);
+                if (class_exists('\core_external\external_api')) {
+                    $validatedvalues = \core_external\external_api::clean_returnvalue(
+                        $this->function->returns_desc,
+                        $this->returns
+                    );
+                } else {
+                    // TODO: Remove this branch condition once Moodle 4.1 is out of support.
+                    $validatedvalues = external_api::clean_returnvalue($this->function->returns_desc, $this->returns);
+                }
                 $encodingoptions = array(
                     "encoding" => "UTF-8",
                     "verbosity" => "no_white_space",

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+// phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.xmlrpc_decodeRemoved
+// phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.xmlrpc_encode_requestRemoved
+// phpcs:disable PHPCompatibility.FunctionUse.RemovedFunctions.xmlrpc_is_faultRemoved
 /**
  * Unit tests for the XML-RPC web service.
  *

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -72,9 +72,16 @@ class locallib_test extends \advanced_testcase {
         $rcm = $rc->getMethod('prepare_response');
         $rcm->setAccessible(true);
 
+        if (class_exists('\core_external\external_value')) {
+            $evalue = new \core_external\external_value(PARAM_RAW, $returnsdesc, VALUE_OPTIONAL);
+        } else {
+            // TODO: Remove this branch condition once Moodle 4.1 is out of support.
+            $evalue = new \external_value(PARAM_RAW, $returnsdesc, VALUE_OPTIONAL);
+        }
         $func = $rc->getProperty('function');
         $func->setAccessible(true);
-        $func->setValue($server, (object) ['returns_desc' => new \external_value(PARAM_RAW, $returnsdesc, VALUE_OPTIONAL)]);
+
+        $func->setValue($server, (object) ['returns_desc' => $evalue]);
 
         $ret = $rc->getProperty('returns');
         $ret->setAccessible(true);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->release   = '1.0.2';
-$plugin->version   = 2022110800;          // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2022110600;          // Requires this Moodle version (4.1dev, when removed from core, or later).
+$plugin->release = '1.0.2';
+$plugin->version = 2022110800;          // The current plugin version (Date: YYYYMMDDXX).
+$plugin->requires = 2022110600;          // Requires this Moodle version (4.1dev, when removed from core, or later).
 $plugin->component = 'webservice_xmlrpc'; // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
This is part of the php81 epic:

https://tracker.moodle.org/browse/MDL-73016

It's near completed and passing in CIs, so let's enable the php81 tests for both MOODLE_401_STABLE and master (4.2dev).

Note that some extra changes have been performed in order to:

1. Provide compatibility for both 4.1 and 4.2 with the, now moved, external stuff.
2. Various coding-style small changes and avoiding false positives.