### PR TITLE
Bump 402 and master tests from php81 to php82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,19 @@ jobs:
       matrix:
         include:
           # Highest php versions supported by each branch (with master always being tested twice).
-          - php: 8.1
+          - php: 8.2
             moodle-branch: master
             database: pgsql
             # The following line is only needed if you're going to run php8 jobs and your
             # plugin needs xmlrpc services.
             extensions: xmlrpc-beta
-          - php: 8.1
+          - php: 8.2
             moodle-branch: master
             database: mariadb
             # The following line is only needed if you're going to run php8 jobs and your
             # plugin needs xmlrpc services.
             extensions: xmlrpc-beta
-          - php: 8.1
+          - php: 8.2
             moodle-branch: MOODLE_402_STABLE
             database: mariadb
             # The following line is only needed if you're going to run php8 jobs and your


### PR DESCRIPTION
With the PHP 8.2 epic (https://tracker.moodle.org/browse/MDL-76405) near being completed, it's time to verify and continuously test that everything is passing with that PHP version.