### PR TITLE
Bump to Moodle 4.4 requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,13 @@ jobs:
             extensions: xmlrpc-beta
 
           # Lowest php versions supported by each branch (with master always being tested twice).
-          - php: 8.0
+          - php: 8.1
             moodle-branch: master
             database: pgsql
             # The following line is only needed if you're going to run php8 jobs and your
             # plugin needs xmlrpc services.
             extensions: xmlrpc-beta
-          - php: 8.0
+          - php: 8.1
             moodle-branch: master
             database: mariadb
             # The following line is only needed if you're going to run php8 jobs and your


### PR DESCRIPTION
Changes:
  - php81 is now required for 4.4dev and up